### PR TITLE
Fixed bugs in inprod.fdata and integrate.simpson

### DIFF
--- a/R/inprod.fdata.R
+++ b/R/inprod.fdata.R
@@ -3,7 +3,6 @@ if (!inherits(fdata1,"fdata")) stop("No fdata class")
 tt1<-fdata1[["argvals"]]
 DATA1<-fdata1[["data"]]
 nas1<-is.na.fdata(fdata1)
-rtt<-fdata1[["rangeval"]]
 if (any(nas1)) {
    stop("fdata1 contain ",sum(nas1)," curves with some NA value \n")
    }
@@ -21,8 +20,7 @@ if (any(nas1)) {
  eps<-as.double(.Machine[[1]]*10)
  inf<-dtt-eps;sup<-dtt+eps
  np<-length(tt1)
- if (all(dtt>inf) & all(dtt<sup)) {equi=TRUE}
- else equi=FALSE
+ equi<-all(abs(diff(tt,lag=2))<eps) # Check if data is equispaced
  if ((length(w)!=np) & (length(w) != 1)) {
     stop("DATA ERROR: The weight vector hasn't the length of the functions\n")
  }

--- a/R/int.simpson.R
+++ b/R/int.simpson.R
@@ -3,16 +3,8 @@ int.simpson=function(fdataobj,equi=TRUE,method="TRAPZ"){
  n<-nrow(fdataobj)
  out<-rep(NA,n)
  tt<-fdataobj$argvals
- if (equi & method=="TRAPZ"){   
-  p<-length(tt)
-#  w<-(c(0,tt[2:(p)-tt[1:(p-1)]])+c(tt[2:(p)-tt[1:(p-1)]],0))/(p-1)
-  w<-(c(0,tt[2:(p)]-tt[1:(p-1)])+c(tt[2:(p)]-tt[1:(p-1)],0))/2
-  out<-drop(fdataobj$data%*%w )
- }
- else{
  for (i in 1:n) {
    out[i]<-int.simpson2(tt,fdataobj$data[i,],equi=equi,method=method)
-   }
    }
 	return(out)
 }
@@ -24,8 +16,15 @@ int.simpson2=function(x,y,equi=TRUE,method="TRAPZ"){
 	if (n==2 || ny==2) method="TRAPZ"
   out <- switch(method,
         "TRAPZ" = {
-   		idx=2:length(x)
-	    value<-as.double((x[idx]-x[idx-1])%*%(y[idx]+y[idx-1]))/2
+        if (!equi){
+       		idx=2:n
+    	    value<-as.double((x[idx]-x[idx-1])%*%(y[idx]+y[idx-1]))/2
+        } else {
+          h=(max(x)-min(x))/(n-1)
+          y[c(1,n)]=y[c(1,n)]/2
+          value<-h*sum(y)
+        }
+        value
 	  },"CSR" = {
      if (!equi){
         n=2*n-1


### PR DESCRIPTION
Comments:

- inprod.fdata was not taking into account if the data was equispaced as the logical condition to detect non-equispaced data was flawed
- integrate.simpson and integrate.simpson2 were using the non-equispaced trapezoidal rule even if the data was equispaced
- I did minor refactor of integrate.simpson and integrate.simpson2

More details on the comments of each commit.